### PR TITLE
feat: 임의의 user agent를 받을 수 있는 파라미터 추가

### DIFF
--- a/app/src/main/java/com/iamport/sampleapp/ui/PaymentFragment.kt
+++ b/app/src/main/java/com/iamport/sampleapp/ui/PaymentFragment.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.*
 
-class PaymentFragment: Fragment() {
+class PaymentFragment : Fragment() {
 
     private lateinit var binding: PaymentFragmentBinding
 

--- a/sdk/src/main/java/com/iamport/sdk/domain/core/Iamport.kt
+++ b/sdk/src/main/java/com/iamport/sdk/domain/core/Iamport.kt
@@ -65,6 +65,8 @@ object Iamport {
     // default WebSettings.LOAD_NO_CACHE 이나, 세틀뱅크 뒤로가기시 오동작하여(캐시가 필요) 가맹점에서 선택할 수 있게 수정
     var webViewCacheMode: Int = WebSettings.LOAD_NO_CACHE
 
+    var customUserAgent: String? = null // 웹뷰 user agent 조작
+
     var response: IamPortResponse? = null // 내부의 imp_uid로 종료 콜백 중복호출 방지
 
     // ===========================================
@@ -297,7 +299,8 @@ object Iamport {
         tierCode: String? = null,
         webviewMode: WebView? = null,
         iamPortCertification: IamPortCertification,
-        resultCallback: (IamPortResponse?) -> Unit
+        customUserAgent: String? = null,
+        resultCallback: (IamPortResponse?) -> Unit,
     ) {
         val payment = Payment(userCode, tierCode = tierCode, iamPortCertification = iamPortCertification)
         if (!isSDKInit(payment)) {
@@ -310,14 +313,16 @@ object Iamport {
         }
 
         preventOverlapRun.launch {
-            coreCertification(payment, resultCallback)
+            coreCertification(payment, customUserAgent, resultCallback)
         }
     }
 
     internal fun coreCertification(
         payment: Payment,
+        customUserAgent: String? = null,
         paymentResultCallback: ((IamPortResponse?) -> Unit)?
     ) {
+        if (customUserAgent != null) this.customUserAgent = customUserAgent
         impCallbackFunction = paymentResultCallback
         iamportSdk?.initStart(payment, paymentResultCallback)
     }

--- a/sdk/src/main/java/com/iamport/sdk/presentation/activity/BaseMain.kt
+++ b/sdk/src/main/java/com/iamport/sdk/presentation/activity/BaseMain.kt
@@ -36,6 +36,7 @@ interface BaseMain {
             }
 
             cacheMode = Iamport.webViewCacheMode // default WebSettings.LOAD_NO_CACHE
+            if (Iamport.customUserAgent != null) userAgentString = Iamport.customUserAgent
 
             blockNetworkImage = false
             loadsImagesAutomatically = true


### PR DESCRIPTION
웹뷰에서 다날 휴대폰 본인인증시 pass 인증창에서 직접적으로 pass 앱을 호출하지 못하도록 막혀있는데 이는 user agent를 변조함으로써 우회 가능하므로 필요에 따라 pass 앱을 열 수 있게 user agent를 받는 파라미터를 Iamport.certification에 추가했습니다.