### PR TITLE
불필요한 koin compose dependency 제거

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,8 +1,8 @@
 // 디펜던시 업데이트 확인 ./gradlew dependencyUpdates
 
 object Versions {
-    const val versionCode = 240725000 // yymmdd000
-    const val versionName = "1.4.5"  // https://www.notion.so/chaifinance/QA-Process-d1a4be396337493b81c6e85fff2d5cd6
+    const val versionCode = 240827000 // yymmdd000
+    const val versionName = "1.4.6"  // https://www.notion.so/chaifinance/QA-Process-d1a4be396337493b81c6e85fff2d5cd6
 
     const val multidex = "2.0.1"
     const val kotlin_stdlib_jdk = "1.9.10"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -99,10 +99,6 @@ object Libs {
     // Koin Java Compatibility
     const val koin_android_compat = "io.insert-koin:koin-android-compat:${Versions.koin_version}"
 
-    // Koin for Jetpack Compose
-    const val koin_android_compose = "io.insert-koin:koin-androidx-compose:${Versions.koin_version}"
-
-
     // Retorofit
     const val retrofit = "com.squareup.retrofit2:retrofit:${Versions.retrofit_version}"
     const val converter_gson = "com.squareup.retrofit2:converter-gson:${Versions.retrofit_version}"

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -119,7 +119,6 @@ dependencies {
     testImplementation(Libs.koin_test_junit4)
     implementation(Libs.koin_android)
     implementation(Libs.koin_android_compat)
-    implementation(Libs.koin_android_compose)
 
     // Retorofit
     implementation(Libs.retrofit)


### PR DESCRIPTION
현재 DI library인 koin에서 ui toolkit인 compose와 함께 사용할 수 있는  라이브러리인 `koin-androidx-compose`를 제공하고 있는데, 현재 sdk에서 유의미하게 사용하고 있는 부분이 없고, compose를 사용하는 일부 고객사들에 중복 dependency 문제가 발생하고 있어 이를 제거한 PR입니다.

이슈 발생 고객사
<img width="837" alt="image" src="https://github.com/user-attachments/assets/780aacc2-5aeb-4bdb-bdfa-9e300c16be4b">
